### PR TITLE
Update Readme for simpler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Includes PHPUnit and PHPCodeSniffer configuration, as well as a known good Travi
 Also includes my [Artisan Standalone](https://github.com/matthewbdaly/artisan-standalone) package as a development dependency. As a result, you should be able to run Artisan commands as follows:
 
 ```bash
-php vendor/bin/artisan make:model Example
+vendor/bin/artisan make:model Example
 ```
 
 How do I use it?
@@ -22,7 +22,7 @@ This will generate a starting boilerplate for your app.
 ###### Step 2
 You'll want to update your `composer.json` with your required namespace and other details - you can do this by running
 ```bash
- php vendor\bin\artisan app:name InsertYourProjectNameHere
+ vendor/bin/artisan app:name InsertYourProjectNameHere
  ```
 
 Test cases

--- a/README.md
+++ b/README.md
@@ -7,17 +7,23 @@ Includes PHPUnit and PHPCodeSniffer configuration, as well as a known good Travi
 Also includes my [Artisan Standalone](https://github.com/matthewbdaly/artisan-standalone) package as a development dependency. As a result, you should be able to run Artisan commands as follows:
 
 ```bash
-vendor/bin/artisan make:model Example
+php vendor/bin/artisan make:model Example
 ```
 
 How do I use it?
 ----------------
-
+###### Step 1
 ```bash
 composer create-project matthewbdaly/laravel-package-boilerplate <YOUR_NEW_PACKAGE_DIRECTORY>
 ```
 
-This will generate a starting boilerplate for your app. You'll want to update your `composer.json` with your required namespace and other details - you can do this by running `vendor\bin\artisan app:name`.
+This will generate a starting boilerplate for your app.
+
+###### Step 2
+You'll want to update your `composer.json` with your required namespace and other details - you can do this by running
+```bash
+ php vendor\bin\artisan app:name InsertYourProjectNameHere
+ ```
 
 Test cases
 ----------


### PR DESCRIPTION
If someone is using the boilerplate, they may be new to Laravel, like me. I know was scratching my head for a while.

Your artisan README.me instructions were missing the php prefix.

**Was:**
`vendor\bin\artisan app:name InsertYourProjectNameHere`

**Now:**
`php vendor\bin\artisan app:name InsertYourProjectNameHere`